### PR TITLE
Don't configure BigDecimal overrides on Ruby 2.3+

### DIFF
--- a/lib/avatax/connection.rb
+++ b/lib/avatax/connection.rb
@@ -19,9 +19,11 @@ module AvaTax
       }.merge(connection_options)
 
       Faraday.new(options) do |faraday|
-        Oj.default_options = {
-          bigdecimal_load: :bigdecimal
-        }
+        if Gem::Version.new(RUBY_VERSION) > Gem::Version.new('2.2.2')
+          Oj.default_options = {
+            bigdecimal_load: :bigdecimal
+          }
+        end
 
         faraday.response :oj, content_type: /\bjson$/
         faraday.basic_auth(username, password)


### PR DESCRIPTION
The `Oj` gem is configured to monkey-patch `BigDecimal` in earlier
versions of Ruby, but on later versions of Ruby (like 2.3 and 2.4), we
are seeing unexpected values appear in JSON-parsed floats after
performing precision arithmetic on them.

I wasn't able to test this locally because even when providing
`credentials.yml` file and a `$SANDBOX_USERNAME` / `$SANDBOX_PASSWORD` in the
shell, all tests failed because it couldn't find the right `companies` data in
spec helper, but the fix definitely does work in my real-world application. Is there
something I can do to test this locally?