### PR TITLE
DEVCON2992

### DIFF
--- a/lib/avatax/configuration.rb
+++ b/lib/avatax/configuration.rb
@@ -16,6 +16,7 @@ module AvaTax
       :connection_options,
       :logger,
       :proxy,
+      :faraday_response
     ].freeze
 
     DEFAULT_APP_NAME = nil
@@ -28,6 +29,7 @@ module AvaTax
     DEFAULT_CONNECTION_OPTIONS = {}
     DEFAULT_LOGGER = false
     DEFAULT_PROXY = nil
+    DEFAULT_FARADAY_RESPONSE = false
 
     attr_accessor *VALID_OPTIONS_KEYS
 
@@ -58,6 +60,7 @@ module AvaTax
       self.connection_options = DEFAULT_CONNECTION_OPTIONS
       self.logger = DEFAULT_LOGGER
       self.proxy = DEFAULT_PROXY
+      self.faraday_response = DEFAULT_FARADAY_RESPONSE
     end
 
   end

--- a/lib/avatax/request.rb
+++ b/lib/avatax/request.rb
@@ -33,12 +33,11 @@ module AvaTax
         end
       end
 
-      if self.faraday_response
+      if faraday_response
         response
       else
-        #::Hashie::Mash.new response.body
         response.body
+      end
     end
-
   end
 end

--- a/lib/avatax/request.rb
+++ b/lib/avatax/request.rb
@@ -1,4 +1,5 @@
 require 'hashie'
+require 'faraday'
 require 'json'
 
 module AvaTax
@@ -32,8 +33,11 @@ module AvaTax
         end
       end
 
-      #::Hashie::Mash.new response.body
-      response.body
+      if self.faraday_response
+        response
+      else
+        #::Hashie::Mash.new response.body
+        response.body
     end
 
   end

--- a/spec/avatax/client/transactions_spec.rb
+++ b/spec/avatax/client/transactions_spec.rb
@@ -37,4 +37,44 @@ describe AvaTax::Client do
     end
 
   end
+
+
+  # Test the option of faraday_response, the returned response should be a type of Faraday response rather than Hashie
+  describe ".transaction_with_faraday_response" do
+    before do
+      @client.faraday_response = true
+      @base_transaction = {
+        type: 'SalesInvoice',
+        companyCode: @company_code,
+        date: '2017-06-05',
+        customerCode: 'ABC',
+        addresses: {
+          ShipFrom: {
+            line1: "123 Main Street",
+            city: "Irvine",
+            region: "CA",
+            country: "US",
+            postalCode: "92615"
+          },
+          ShipTo: {
+            line1: "100 Market Street",
+            city: "San Francisco",
+            region: "CA",
+            country: "US",
+            postalCode: "94105"
+          }
+        },
+        lines: [{amount: 100}]
+      }
+    end
+
+    it "should create a transaction and return the faraday response" do
+      faraday_trans = @client.create_transaction(@base_transaction)
+      expect(faraday_trans).to be_a Object
+      expect(faraday_trans["status"]) == 201
+      expect(faraday_trans["reason_phrase"]) == "Created"
+      expect(faraday_trans["request_headers"]).to be_a Object
+      expect(faraday_trans["body"]).to be_a Object
+    end
+  end
 end


### PR DESCRIPTION
Implemented an option for returning Faraday response versus regular Hashie response when the user initiates the Client object, in response to #8 

To use this feature 
`@client = AvaTax::Client.new(:faraday_response => true)` on new Client object
`@client.faraday_response = true` on existing Client object