### PR TITLE
Include Customers module in the client

### DIFF
--- a/lib/avatax/client.rb
+++ b/lib/avatax/client.rb
@@ -7,6 +7,7 @@ module AvaTax
     include AvaTax::Client::Batches
     include AvaTax::Client::Companies
     include AvaTax::Client::Contacts
+    include AvaTax::Client::Customers
     include AvaTax::Client::Definitions
     include AvaTax::Client::FilingCalendars
     include AvaTax::Client::Filings


### PR DESCRIPTION
I noticed `AvaTax::Client` was missing methods related to the [Customers API](https://developer.avalara.com/api-reference/avatax/rest/v2/methods/Customers/), but there was already a module that just wasn't being included like the rest of them.