### PR TITLE
Make AvaTax::Client::CertExpressInvites methods available to client

### DIFF
--- a/lib/avatax/client.rb
+++ b/lib/avatax/client.rb
@@ -5,6 +5,7 @@ module AvaTax
     include AvaTax::Client::Accounts
     include AvaTax::Client::Addresses
     include AvaTax::Client::Batches
+    include AvaTax::Client::CertExpressInvites
     include AvaTax::Client::Companies
     include AvaTax::Client::Contacts
     include AvaTax::Client::Customers


### PR DESCRIPTION
Adds the `CertExpressInvites` module to `AvaTax::Client`.