### PR TITLE
Remove unused hashie dependency, fix tests

### DIFF
--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday', '>= 0.10')
   s.add_runtime_dependency('faraday_middleware', '>= 0.10')
   s.add_runtime_dependency('multi_json', '>= 1.0.3')
-  s.add_runtime_dependency('hashie', '>= 3.0.0')
   s.add_runtime_dependency('faraday_middleware-parse_oj', '~> 0.3.2')
   s.authors = ["Marcus Vorwaller"]
   s.description = %q{A Ruby wrapper for the AvaTax REST and Search APIs}

--- a/lib/avatax/request.rb
+++ b/lib/avatax/request.rb
@@ -1,4 +1,3 @@
-require 'hashie'
 require 'faraday'
 require 'json'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -22,6 +22,6 @@ companies = client.query_companies
 RSpec.configure do |config|
   config.before {
     @client = client
-    @company_code = companies["value"][1]["companyCode"]
+    @company_code = companies["value"][0]["companyCode"]
   }
 end


### PR DESCRIPTION
Hashie is listed as a runtime dependency but its usage was removed over a year ago: https://github.com/avadev/AvaTax-REST-V2-Ruby-SDK/commit/e801b88e50203673c807877f1b8c136227a47344#diff-12445b024331a291582b8e7d9c204dc0R35

