### PR TITLE
use request.url even in the case of post/put

### DIFF
--- a/lib/avatax/request.rb
+++ b/lib/avatax/request.rb
@@ -26,7 +26,7 @@ module AvaTax
         when :get, :delete
           request.url("#{URI.encode(path)}?#{URI.encode_www_form(options)}")
         when :post, :put
-          request.path = ("#{URI.encode(path)}?#{URI.encode_www_form(options)}")
+          request.url("#{URI.encode(path)}?#{URI.encode_www_form(options)}")
           request.headers['Content-Type'] = 'application/json'
           request.body = model.to_json unless model.empty?
         end


### PR DESCRIPTION
Fixes #45 

Not a huge fan of the duplication, but it's the least minimally invasive change logic-wise. It looks like `Faraday::Request#url` will also accept a hash of params as the second argument, but I'm not sure about the encoding.