### PR TITLE
Remove post install message

### DIFF
--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -10,21 +10,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday_middleware-parse_oj', '~> 0.3.2')
   s.authors = ["Marcus Vorwaller"]
   s.description = %q{A Ruby wrapper for the AvaTax REST and Search APIs}
-  s.post_install_message =<<eos
-********************************************************************************
-
-AvaTax REST API
-------------------------------
-Our developer site documents the AvaTax REST API.
-(http://developer.avatax.com).
-Blog
-----------------------------
-The Developer Blog is a great place to learn more about the API and AvaTax integrations
-Subscribe to the RSS feed be notified of new posts:
-(http://developer.avatax.com/blog).
-
-********************************************************************************
-eos
   s.email = ['marcus.vorwaller@avalara.com']
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.files = `git ls-files`.split("\n")


### PR DESCRIPTION
**Proposal: remove post install message.**

When I `bundle`, my brain lazily watches for something different to mean _something changed or is gonna change._ When a post-install message comes up, I expect it to be about a deprecation warning or a breaking change. I don't expect it to be a link to documentation. 

I'm already on board to use the gem. The name "AvaTax" is already pretty googleable. The name "AvaTax-REST-V2-Ruby-SDK" is even more so. If I need the docs for this gem, googling the name of the gem would get me to this repo where there are the same links to the developer site and blog.

In the spirit of reducing the visual noise in a normal, uneventful `bundle install`, can y'all remove this post-install message, please?

Thanks