### PR TITLE
replace oj middleware with standard faraday parsejson

### DIFF
--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -7,7 +7,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday', '>= 0.10')
   s.add_runtime_dependency('faraday_middleware', '>= 0.10')
   s.add_runtime_dependency('multi_json', '>= 1.0.3')
-  s.add_runtime_dependency('faraday_middleware-parse_oj', '~> 0.3.2')
   s.authors = ["Marcus Vorwaller"]
   s.description = %q{A Ruby wrapper for the AvaTax REST and Search APIs}
   s.post_install_message =<<eos

--- a/lib/avatax/connection.rb
+++ b/lib/avatax/connection.rb
@@ -1,4 +1,4 @@
-require 'faraday_middleware/parse_oj'
+require 'faraday_middleware'
 
 module AvaTax
 
@@ -27,7 +27,7 @@ module AvaTax
           }
         end
 
-        faraday.response :oj, content_type: /\bjson$/
+        faraday.response :json, content_type: /\bjson$/
         faraday.basic_auth(username, password)
 
         if logger


### PR DESCRIPTION
This allows the gem to work with faraday 1.0 and greater.  The tests pass.