### PR TITLE
Fixes #81:  re-enable setting custom request timeouts

### DIFF
--- a/lib/avatax/configuration.rb
+++ b/lib/avatax/configuration.rb
@@ -29,7 +29,7 @@ module AvaTax
     DEFAULT_USER_AGENT = "AvaTax Ruby Gem #{AvaTax::VERSION}".freeze
     DEFAULT_USERNAME = nil
     DEFAULT_PASSWORD = nil
-    DEFAULT_CONNECTION_OPTIONS = {}
+    DEFAULT_CONNECTION_OPTIONS = {request: {timeout: 1200}} # timeout in seconds
     DEFAULT_LOGGER = false
     DEFAULT_CUSTOM_LOGGER = nil
     DEFAULT_CUSTOM_LOGGER_OPTIONS = {}

--- a/lib/avatax/request.rb
+++ b/lib/avatax/request.rb
@@ -22,8 +22,6 @@ module AvaTax
 
     def request(method, path, model, options={})
       response = connection.send(method) do |request|
-        # timeout in seconds
-        request.options['timeout'] = 1200
         case method
         when :get, :delete
           request.url("#{URI.encode(path)}?#{URI.encode_www_form(options)}")

--- a/spec/avatax/request_spec.rb
+++ b/spec/avatax/request_spec.rb
@@ -1,0 +1,25 @@
+require File.expand_path('../../spec_helper', __FILE__)
+
+describe AvaTax::Request do
+
+  describe ".request" do
+    it "should default to a 1200 second timeout" do
+      @client.faraday_response = true
+      response = @client.request(:get, 'path', 'model')
+      expect(response.env.request['timeout']).to eq(1200)
+    end
+
+    it "should allow setting a custom timeout" do
+      @client.faraday_response = true
+      @client.connection_options = {
+        request: {
+          open_timeout: 5,
+          timeout: 10
+        }
+      }
+      response = @client.request(:get, 'path', 'model')
+      expect(response.env.request['open_timeout']).to eq(5)
+      expect(response.env.request['timeout']).to eq(10)
+    end
+  end
+end


### PR DESCRIPTION
This fixes issue #81 and provides an alternative implementation for PR #72, which caused a regression in the ability for callers to set custom request timeouts.

I covered the default 1200s timeout in a test and asserted it passed before and after the refactor to use DEFAULT_CONNECTION_OPTIONS.