### PR TITLE
Addressing issue with Util.Encode

### DIFF
--- a/lib/avatax/request.rb
+++ b/lib/avatax/request.rb
@@ -1,5 +1,7 @@
 require 'faraday'
 require 'json'
+require "erb"
+
 
 module AvaTax
   module Request
@@ -24,9 +26,9 @@ module AvaTax
       response = connection.send(method) do |request|
         case method
         when :get, :delete
-          request.url("#{URI.encode(path)}?#{URI.encode_www_form(options)}")
+          request.url("#{encode_path(path)}?#{URI.encode_www_form(options)}")
         when :post, :put
-          request.url("#{URI.encode(path)}?#{URI.encode_www_form(options)}")
+          request.url("#{encode_path(path)}?#{URI.encode_www_form(options)}")
           request.headers['Content-Type'] = 'application/json'
           request.body = model.to_json unless model.empty?
         end
@@ -37,6 +39,12 @@ module AvaTax
       else
         response.body
       end
+    end
+
+    private
+
+    def encode_path(path)
+      path.split('/').map { |part| ERB::Util.url_encode(part) }.join('/')
     end
   end
 end


### PR DESCRIPTION
This is going to resolve following issues: 

1. Address deprecated method:  Util.Encode and replace with ERB::Util.url_encode
2. Added missing require erb - need to access Util.url_encode @joshski
https://github.com/avadev/AvaTax-REST-V2-Ruby-SDK/pull/100