### PR TITLE
FG-8184: Update faraday basic auth syntax

### DIFF
--- a/lib/avatax/connection.rb
+++ b/lib/avatax/connection.rb
@@ -27,8 +27,8 @@ module AvaTax
           }
         end
 
+        faraday.request :basic_auth, username, password
         faraday.response :json, content_type: /\bjson$/
-        faraday.basic_auth(username, password)
 
         if logger
           faraday.response :logger do |logger|


### PR DESCRIPTION
Related tickets: 

* [FG-7785](https://yourguru.atlassian.net/browse/FG-7785) - Fix WARNING: `Faraday::Connection#basic_auth`in tests