### PR TITLE
Load Multi Document module

### DIFF
--- a/lib/avatax/client.rb
+++ b/lib/avatax/client.rb
@@ -33,5 +33,6 @@ module AvaTax
     include AvaTax::Client::Utilities
     include AvaTax::Client::ShippingVerification
     include AvaTax::Client::AgeVerification
+    include AvaTax::Client::MultiDocument
   end
 end


### PR DESCRIPTION
Methods from MultiDocument module are not available when using the gem. This simple include fixes the issue 