### PR TITLE
Changed the uncommit_transaction and unvoid_transaction methods to pass empty hash for model

### DIFF
--- a/lib/avatax/client/transactions.rb
+++ b/lib/avatax/client/transactions.rb
@@ -1,6 +1,6 @@
 module AvaTax
   class Client
-    module Transactions 
+    module Transactions
 
 
       # Add lines to an existing unlocked transaction
@@ -30,7 +30,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, BatchServiceAdmin, CompanyAdmin, CSPTester, SSTAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param include [String] Specifies objects to include in the response after transaction is created
       # @param model [Object] information about the transaction and lines to be added
       # @return [Object]
@@ -73,7 +73,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, BatchServiceAdmin, CompanyAdmin, CSPTester, SSTAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param transactionCode [String] The transaction code to adjust
       # @param documentType [String] (Optional): The document type of the transaction to adjust. (See DocumentType::* for a list of allowable values)
@@ -113,7 +113,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPAdmin, CSPTester, ProStoresOperator, SiteAdmin, SSTAdmin, SystemAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The code identifying the company that owns this transaction
       # @param transactionCode [String] The code identifying the transaction
       # @return [Object]
@@ -150,7 +150,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPAdmin, CSPTester, ProStoresOperator, SiteAdmin, SSTAdmin, SystemAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The code identifying the company that owns this transaction
       # @param transactionCode [String] The code identifying the transaction
       # @param documentType [String] The document type of the original transaction (See DocumentType::* for a list of allowable values)
@@ -172,7 +172,7 @@ module AvaTax
       #
       # * This API requires the user role Compliance Root User.
       # * This API depends on the following active services:*Returns* (at least one of): Mrs, MRSComplianceManager, AvaTaxCsp.*Firm Managed* (for accounts managed by a firm): ARA, ARAManaged.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param model [Object] bulk lock request
       # @return [Object]
       def bulk_lock_transaction(model)        path = "/api/v2/transactions/lock"
@@ -214,7 +214,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, ProStoresOperator, SSTAdmin, TechnicalSupportAdmin.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param transactionCode [String] The transaction code to change
       # @param documentType [String] (Optional): The document type of the transaction to change document code. If not provided, the default is SalesInvoice. (See DocumentType::* for a list of allowable values)
@@ -258,7 +258,7 @@ module AvaTax
       # ### Security Policies
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, ProStoresOperator, SSTAdmin, TechnicalSupportAdmin.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param transactionCode [String] The transaction code to commit
       # @param documentType [String] (Optional): The document type of the transaction to commit. If not provided, the default is SalesInvoice. (See DocumentType::* for a list of allowable values)
@@ -308,7 +308,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, SSTAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param include [String] Specifies objects to include in the response after transaction is created
       # @param model [Object] The transaction you wish to create or adjust
       # @return [Object]
@@ -362,7 +362,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, SSTAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param include [String] Specifies objects to include in the response after transaction is created
       # @param model [Object] The transaction you wish to create
       # @return [Object]
@@ -393,7 +393,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, BatchServiceAdmin, CompanyAdmin, CSPTester, SSTAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param include [String] Specifies objects to include in the response after transaction is created
       # @param model [Object] information about the transaction and lines to be removed
       # @return [Object]
@@ -433,7 +433,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPAdmin, CSPTester, ProStoresOperator, SiteAdmin, SSTAdmin, SystemAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param transactionCode [String] The transaction code to retrieve
       # @param documentType [String] (Optional): The document type of the transaction to retrieve (See DocumentType::* for a list of allowable values)
@@ -458,7 +458,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPAdmin, CSPTester, ProStoresOperator, SiteAdmin, SSTAdmin, SystemAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param transactionCode [String] The transaction code to retrieve
       # @param documentType [String] The transaction type to retrieve (See DocumentType::* for a list of allowable values)
@@ -490,7 +490,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPAdmin, CSPTester, ProStoresOperator, SiteAdmin, SSTAdmin, SystemAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param id [Integer] The unique ID number of the transaction to retrieve
       # @param include [String] Specifies objects to include in this fetch call
       # @return [Object]
@@ -533,7 +533,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPAdmin, CSPTester, ProStoresOperator, SiteAdmin, SSTAdmin, SystemAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param dataSourceId [Integer] Optionally filter transactions to those from a specific data source.
       # @param include [String] Specifies objects to include in this fetch call
@@ -581,7 +581,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, SSTAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Returns* (at least one of): Mrs, MRSComplianceManager, AvaTaxCsp.*Firm Managed* (for accounts managed by a firm): ARA, ARAManaged.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param transactionCode [String] The transaction code to lock
       # @param documentType [String] (Optional): The document type of the transaction to lock. If not provided, the default is SalesInvoice. (See DocumentType::* for a list of allowable values)
@@ -637,7 +637,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, SSTAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The code of the company that made the original sale
       # @param transactionCode [String] The transaction code of the original sale
       # @param include [String] Specifies objects to include in the response after transaction is created
@@ -682,7 +682,7 @@ module AvaTax
       # ### Security Policies
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, ProStoresOperator, SSTAdmin, TechnicalSupportAdmin.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param transactionCode [String] The transaction code to settle
       # @param documentType [String] (Optional): The document type of the transaction to settle. If not provided, the default is SalesInvoice. (See DocumentType::* for a list of allowable values)
@@ -721,14 +721,14 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, BatchServiceAdmin, CompanyAdmin, CSPTester, SSTAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param transactionCode [String] The transaction code to Uncommit
       # @param documentType [String] (Optional): The document type of the transaction to Uncommit. If not provided, the default is SalesInvoice. (See DocumentType::* for a list of allowable values)
       # @param include [String] Specifies objects to include in this fetch call
       # @return [Object]
       def uncommit_transaction(companyCode, transactionCode, options={})        path = "/api/v2/companies/#{companyCode}/transactions/#{transactionCode}/uncommit"
-        post(path, options, "22.7.0")      end
+        post(path, {}, options, "22.7.0")      end
 
       # Unvoids a transaction
       #
@@ -756,14 +756,14 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, BatchServiceAdmin, CompanyAdmin, CSPTester, SSTAdmin, TechnicalSupportAdmin, TechnicalSupportUser.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param transactionCode [String] The transaction code to commit
       # @param documentType [String] (Optional): The document type of the transaction to commit. If not provided, the default is SalesInvoice. (See DocumentType::* for a list of allowable values)
       # @param include [String] Specifies objects to include in this fetch call
       # @return [Object]
       def unvoid_transaction(companyCode, transactionCode, options={})        path = "/api/v2/companies/#{companyCode}/transactions/#{transactionCode}/unvoid"
-        post(path, options, "22.7.0")      end
+        post(path, {}, options, "22.7.0")      end
 
       # Verify a transaction
       #
@@ -798,7 +798,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, AccountUser, BatchServiceAdmin, CompanyAdmin, CompanyUser, CSPTester, ProStoresOperator, SSTAdmin, TechnicalSupportAdmin.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param transactionCode [String] The transaction code to settle
       # @param documentType [String] (Optional): The document type of the transaction to verify. If not provided, the default is SalesInvoice. (See DocumentType::* for a list of allowable values)
@@ -843,7 +843,7 @@ module AvaTax
       #
       # * This API requires one of the following user roles: AccountAdmin, AccountOperator, BatchServiceAdmin, CompanyAdmin, CSPTester, ProStoresOperator, SSTAdmin, TechnicalSupportAdmin.
       # * This API depends on the following active services:*Required* (all): AvaTaxPro, BasicReturns.
-      # Swagger Name: AvaTaxClient	  
+      # Swagger Name: AvaTaxClient
       # @param companyCode [String] The company code of the company that recorded this transaction
       # @param transactionCode [String] The transaction code to void
       # @param documentType [String] (Optional): The document type of the transaction to void. If not provided, the default is SalesInvoice. (See DocumentType::* for a list of allowable values)

--- a/spec/avatax/client/transactions_spec.rb
+++ b/spec/avatax/client/transactions_spec.rb
@@ -36,6 +36,46 @@ describe AvaTax::Client do
       expect(transaction["status"]).to eq "Saved"
     end
 
+    it "should create a committed transaction" do
+      transaction = @client.create_transaction(@base_transaction.merge!(commit: true))
+
+      expect(transaction).to be_a Object
+      expect(transaction["id"]).to be_a Integer
+      expect(transaction["status"]).to eq "Committed"
+    end
+
+    it "should uncommit a transaction" do
+      create_transaction = @client.create_transaction(@base_transaction.merge!(commit: true))
+
+      uncommit_transaction = @client.uncommit_transaction(@company_code, create_transaction["code"])
+
+      expect(uncommit_transaction).to be_a Object
+      expect(uncommit_transaction["id"]).to be_a Integer
+      expect(uncommit_transaction["status"]).to eq "Saved"
+    end
+
+    it "should void a transaction" do
+      create_transaction = @client.create_transaction(@base_transaction)
+      void_transaction = @client.void_transaction(@company_code, create_transaction["code"], code: "DocVoided")
+
+      expect(void_transaction).to be_a Object
+      expect(void_transaction["id"]).to be_a Integer
+
+      # The API guide specifies that the status should be "DocVoided", however, it is always "Cancelled"
+      expect(void_transaction["status"]).to eq "Cancelled"
+    end
+
+    it "should unvoid a transaction" do
+      create_transaction = @client.create_transaction(@base_transaction)
+      void_transaction = @client.void_transaction(@company_code, create_transaction["code"], code: "DocVoided")
+
+      unvoid_transaction = @client.unvoid_transaction(@company_code, create_transaction["code"])
+
+      expect(unvoid_transaction).to be_a Object
+      expect(unvoid_transaction["id"]).to be_a Integer
+      expect(unvoid_transaction["status"]).to eq "Saved"
+    end
+
   end
 
 


### PR DESCRIPTION
When calling the uncommit_transaction and unvoid_transaction methods the following exception was being raised. This was due to not passing a model to the post method. These transactions do not require a model so I modified it to pass an empty hash. 

 Failure/Error: request.url("#{encode_path(path)}?#{URI.encode_www_form(options)}")

```
     NoMethodError:
       undefined method `map' for "22.7.0":String
       Did you mean?  tap
     # /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/uri/common.rb:419:in `encode_www_form'
     # ./lib/avatax/request.rb:33:in `block in request'
     # /Library/Ruby/Gems/2.6.0/gems/faraday-1.10.0/lib/faraday/connection.rb:513:in `block in run_request'
     # /Library/Ruby/Gems/2.6.0/gems/faraday-1.10.0/lib/faraday/connection.rb:530:in `block in build_request'
     # /Library/Ruby/Gems/2.6.0/gems/faraday-1.10.0/lib/faraday/request.rb:56:in `block in create'
     # /Library/Ruby/Gems/2.6.0/gems/faraday-1.10.0/lib/faraday/request.rb:55:in `tap'
     # /Library/Ruby/Gems/2.6.0/gems/faraday-1.10.0/lib/faraday/request.rb:55:in `create'
     # /Library/Ruby/Gems/2.6.0/gems/faraday-1.10.0/lib/faraday/connection.rb:526:in `build_request'
     # /Library/Ruby/Gems/2.6.0/gems/faraday-1.10.0/lib/faraday/connection.rb:508:in `run_request'
     # /Library/Ruby/Gems/2.6.0/gems/faraday-1.10.0/lib/faraday/connection.rb:281:in `post'
     # ./lib/avatax/request.rb:26:in `request'
     # ./lib/avatax/request.rb:14:in `post'
     # ./lib/avatax/client/transactions.rb:731:in `uncommit_transaction'
     # ./spec/avatax/client/transactions_spec.rb:42:in `block (3 levels) in <top (required)>'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `instance_exec'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:254:in `block in run'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `block in with_around_and_singleton_context_hooks'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `block in with_around_example_hooks'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `block in run'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:602:in `run_around_example_hooks_for'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/hooks.rb:464:in `run'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:453:in `with_around_example_hooks'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:496:in `with_around_and_singleton_context_hooks'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example.rb:251:in `run'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:627:in `block in run_examples'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `map'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:623:in `run_examples'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:589:in `run'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `block in run'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `map'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/example_group.rb:590:in `run'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (3 levels) in run_specs'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `map'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:113:in `block (2 levels) in run_specs'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1835:in `with_suite_hooks'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:112:in `block in run_specs'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/reporter.rb:77:in `report'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:111:in `run_specs'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:87:in `run'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
     # /Library/Ruby/Gems/2.6.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<top (required)>'
     # /usr/local/bin/rspec:23:in `load'
     # /usr/local/bin/rspec:23:in `<main>'

```