### PR TITLE
added logging support for request and response body and request duration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@
 /example/credentials.yaml
 /spec/credentials.yaml
 
+.idea
+
 # Used by dotenv library to load environment variables.
 # .env
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Installation
 Simple Code Example
 -------------------------
 ```ruby
-@client = AvaTax::Client.new(:logger => true)
+@client = AvaTax::Client.new({ :logger => true, :log_request_and_response_info => true })
 
 createTransactionModel = {
   "type" => 'SalesInvoice',

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday', '>= 0.10')
   s.add_runtime_dependency('faraday_middleware', '>= 0.10')
   s.add_runtime_dependency('multi_json', '>= 1.0.3')
+  s.add_runtime_dependency('activesupport', '~> 6.1.7')
   s.authors = ["Marcus Vorwaller"]
   s.description = %q{A Ruby wrapper for the AvaTax REST and Search APIs}
   s.post_install_message =<<eos

--- a/lib/avatax/api.rb
+++ b/lib/avatax/api.rb
@@ -10,6 +10,7 @@ module AvaTax
 
     def initialize(options={})
       options = AvaTax.options.merge(options)
+      # The default logger in Faraday is configured exactly the same as this one, but we cannot get a reference to it, so we will instantiate our own.
       default_logger =  Logger.new(STDOUT)
       Configuration::VALID_OPTIONS_KEYS.each do |key|
         send("#{key}=", options[key])
@@ -20,7 +21,7 @@ module AvaTax
 
         if custom_logger
           custom_logger.info "The request to #{url} took #{duration} ms."
-        else
+        elsif logger
           default_logger.info "The request to #{url} took #{duration} ms."
         end
       end

--- a/lib/avatax/api.rb
+++ b/lib/avatax/api.rb
@@ -1,5 +1,7 @@
 require File.expand_path('../connection', __FILE__)
 require File.expand_path('../request', __FILE__)
+require 'active_support/notifications'
+require 'logger'
 
 module AvaTax
   class API
@@ -8,8 +10,19 @@ module AvaTax
 
     def initialize(options={})
       options = AvaTax.options.merge(options)
+      default_logger =  Logger.new(STDOUT)
       Configuration::VALID_OPTIONS_KEYS.each do |key|
         send("#{key}=", options[key])
+      end
+      ActiveSupport::Notifications.subscribe("request.faraday") do |name, starts, ends, _, env|
+        url      = env[:url]
+        duration = (ends - starts) * 1000
+
+        if custom_logger
+          custom_logger.info "The request to #{url} took #{duration} ms."
+        else
+          default_logger.info "The request to #{url} took #{duration} ms."
+        end
       end
     end
 

--- a/lib/avatax/configuration.rb
+++ b/lib/avatax/configuration.rb
@@ -19,7 +19,8 @@ module AvaTax
       :custom_logger_options,
       :proxy,
       :faraday_response,
-      :response_big_decimal_conversion
+      :response_big_decimal_conversion,
+      :log_request_and_response_info
     ].freeze
 
     DEFAULT_APP_NAME = nil
@@ -36,6 +37,7 @@ module AvaTax
     DEFAULT_PROXY = nil
     DEFAULT_FARADAY_RESPONSE = false
     DEFAULT_RESPONSE_BIG_DECIMAL_CONVERSION = false
+    DEFAULT_LOG_REQUEST_AND_RESPONSE_INFO = false
 
     attr_accessor *VALID_OPTIONS_KEYS
 
@@ -70,6 +72,7 @@ module AvaTax
       self.proxy = DEFAULT_PROXY
       self.faraday_response = DEFAULT_FARADAY_RESPONSE
       self.response_big_decimal_conversion = DEFAULT_RESPONSE_BIG_DECIMAL_CONVERSION
+      self.log_request_and_response_info = DEFAULT_LOG_REQUEST_AND_RESPONSE_INFO
     end
 
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,8 +9,6 @@ AvaTax.configure do |config|
     config.endpoint = credentials['endpoint']
     config.username = credentials['username']
     config.password = credentials['password']
-    config.logger = true
-    config.log_request_and_response_info = true
   else
     config.endpoint = 'https://sandbox-rest.avatax.com'
     config.username = ENV['SANDBOX_USERNAME']
@@ -18,7 +16,7 @@ AvaTax.configure do |config|
   end
 end
 
-client = AvaTax::Client.new()
+client = AvaTax::Client.new({ :logger => true, :log_request_and_response_info => true })
 companies = client.query_companies
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,8 @@ AvaTax.configure do |config|
     config.endpoint = credentials['endpoint']
     config.username = credentials['username']
     config.password = credentials['password']
+    config.logger = true
+    config.log_request_and_response_info = true
   else
     config.endpoint = 'https://sandbox-rest.avatax.com'
     config.username = ENV['SANDBOX_USERNAME']


### PR DESCRIPTION
Logging is supported already in the Ruby SDK for V2, however only headers are currently logged.
Current state: 
1. Logging can be configured by passing a boolean for logger => true
2. A custom logger can be injected into the SDK using the custom_logger attribute.
3. HTTP headers will be logged for Request and Response, Authorization header is hidden.

Changes made in this PR:
1. Added an additional config option log_request_and_response_info which is a boolean (default false). When toggled on, the request and response bodies will also be logged.
2. Added activesupport module which is used be Faraday for instrumenting the requests.
3. Added a handler to calculate the elapsed time of each request and log it.
