### PR TITLE
Allow Rails 7.0: loosen activesupport constraint

### DIFF
--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency('faraday', '>= 0.10')
   s.add_runtime_dependency('faraday_middleware', '>= 0.10')
   s.add_runtime_dependency('multi_json', '>= 1.0.3')
-  s.add_runtime_dependency('activesupport', '~> 6.1.7')
+  s.add_runtime_dependency('activesupport', '>= 6.1.7')
   s.authors = ["Marcus Vorwaller"]
   s.description = %q{A Ruby wrapper for the AvaTax REST and Search APIs}
   s.post_install_message =<<eos


### PR DESCRIPTION
### Context

A new `activesupport` runtime dependency was introduced to the library in #134. It currently has an extremely tight version constraint of `~> 6.1.7`. This expands to `>= 6.1.7, < 6.2`.

Consequently, customers running a version of Rails outside this range are unable to use the latest release of `avatax`.

### Change

Loosen the version constraint for the `activesupport` runtime dependency to 6.1.7 and above (`>= 6.1.7`). This allows customers running the latest version of Rails (7.0 currently) to use new releases of `avatax` again. 

Fixes #137.

### Considerations

You may wish to loosen the constraints further, to support customers running older versions of Rails as well.