### PR TITLE
Faraday compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# FORK NOTE
+===================
+
+This gem was forked from avadev because of its incompatibility with Faraday 2.0, specifically due to Faraday Middleware being required here but not supporting Faraday 2.0. If avatax ever officially supports Faraday 2.0, this gem can be replaced with main from avadev.
+
 The AvaTax Ruby Gem
 ====================
 A Ruby wrapper for the AvaTax REST V2 APIs

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -5,7 +5,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency('rspec', '~> 3.5.0')
   s.add_development_dependency('webmock', '>= 2.0.0')
   s.add_runtime_dependency('faraday', '>= 0.10')
-  s.add_runtime_dependency('faraday_middleware', '>= 0.10')
   s.add_runtime_dependency('multi_json', '>= 1.0.3')
   s.add_runtime_dependency('activesupport', '~> 6.1.7')
   s.authors = ["Marcus Vorwaller"]

--- a/lib/avatax/connection.rb
+++ b/lib/avatax/connection.rb
@@ -1,5 +1,3 @@
-require 'faraday_middleware'
-
 module AvaTax
 
   module Connection
@@ -28,11 +26,7 @@ module AvaTax
         end
         faraday.request :instrumentation
         faraday.response :json, content_type: /\bjson$/
-        faraday.request :basic_auth, username, password
-
-        # TODO: use the following after upgrading to faraday 2.0
-        #   see https://github.com/lostisland/faraday/blob/main/docs/middleware/request/authentication.md
-        # faraday.request :authorization, :basic, username, password
+        faraday.request :authorization, :basic, username, password
 
         default_logger_options = { headers: true, bodies: log_request_and_response_info }
         if logger

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,6 +11,7 @@ AvaTax.configure do |config|
     config.password = credentials['password']
   else
     config.endpoint = 'https://sandbox-rest.avatax.com'
+    # Creds can be found in 1Pass
     config.username = ENV['SANDBOX_USERNAME']
     config.password = ENV['SANDBOX_PASSWORD']
   end


### PR DESCRIPTION
Allows gem to work with Faraday 2.0. To get tests to pass, add env vars mentioned in spec/spec_helper.rb from 1Pass