### PR TITLE
Remove development and test files from the gem package

### DIFF
--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -26,14 +26,16 @@ Subscribe to the RSS feed be notified of new posts:
 ********************************************************************************
 eos
   s.email = ['marcus.vorwaller@avalara.com']
-  s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.files = `git ls-files`.split("\n")
+  s.files = Dir.chdir(__dir__) do
+    `git ls-files -z`.split("\x0").select do |file|
+      file.start_with?('LICENSE', 'README', 'example', 'lib')
+    end
+  end
   s.homepage = 'https://github.com/avadev/AvaTax-REST-V2-Ruby-SDK'
   s.name = 'avatax'
   s.platform = Gem::Platform::RUBY
   s.require_paths = ['lib']
   s.required_rubygems_version = Gem::Requirement.new('>= 2.0.0') if s.respond_to? :required_rubygems_version=
   s.summary = %q{Ruby wrapper for the AvaTax API}
-  s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.version = AvaTax::VERSION.dup
 end


### PR DESCRIPTION
There are a bunch of files in the gem package that aren't useful for downstream projects. Removing these reduces the gem package size from 110K to 77K!

<details><summary>gem contents diff</summary>

```diff
< .github/workflows/gem-push.yml
< .gitignore
< .rspec
< .vs/AvaTax-REST-V2-Ruby-SDK/v15/.suo
< .vs/VSWorkspaceState.json
< .vs/slnx.sqlite
< .yardopts
< Gemfile
  LICENSE
  README.md
< Rakefile
< avatax.gemspec
  example/avatax.rb
  example/credentials.example.yaml
  lib/avatax.rb
  lib/avatax/api.rb
  lib/avatax/client.rb
  lib/avatax/client/accounts.rb
  lib/avatax/client/addresses.rb
  lib/avatax/client/advancedrules.rb
  lib/avatax/client/ageverification.rb
  lib/avatax/client/avafileforms.rb
  lib/avatax/client/batches.rb
  lib/avatax/client/certexpressinvites.rb
  lib/avatax/client/certificates.rb
  lib/avatax/client/companies.rb
  lib/avatax/client/compliance.rb
  lib/avatax/client/contacts.rb
  lib/avatax/client/customers.rb
  lib/avatax/client/datasources.rb
  lib/avatax/client/definitions.rb
  lib/avatax/client/distancethresholds.rb
  lib/avatax/client/ecms.rb
  lib/avatax/client/ecommercetoken.rb
  lib/avatax/client/errortransactions.rb
  lib/avatax/client/filingcalendars.rb
  lib/avatax/client/filings.rb
  lib/avatax/client/firmclientlinkages.rb
  lib/avatax/client/free.rb
  lib/avatax/client/fundingrequests.rb
  lib/avatax/client/items.rb
  lib/avatax/client/jurisdictionoverrides.rb
  lib/avatax/client/locations.rb
  lib/avatax/client/multidocument.rb
  lib/avatax/client/nexus.rb
  lib/avatax/client/notices.rb
  lib/avatax/client/notifications.rb
  lib/avatax/client/onboarding.rb
  lib/avatax/client/pointofsale.rb
  lib/avatax/client/provisioning.rb
  lib/avatax/client/registrar.rb
  lib/avatax/client/reports.rb
  lib/avatax/client/settings.rb
  lib/avatax/client/shippingverification.rb
  lib/avatax/client/subscriptions.rb
  lib/avatax/client/taxContent/README.txt
  lib/avatax/client/taxRatesByZip/README.txt
  lib/avatax/client/taxcodes.rb
  lib/avatax/client/taxcontent.rb
  lib/avatax/client/taxprofiles.rb
  lib/avatax/client/taxrules.rb
  lib/avatax/client/transactions.rb
  lib/avatax/client/upcs.rb
  lib/avatax/client/userdefinedfields.rb
  lib/avatax/client/users.rb
  lib/avatax/client/utilities.rb
  lib/avatax/configuration.rb
  lib/avatax/connection.rb
  lib/avatax/request.rb
  lib/avatax/version.rb
< spec/avatax/client/accounts_spec.rb
< spec/avatax/client/transactions_spec.rb
< spec/avatax/request_spec.rb
< spec/avatax_spec.rb
< spec/credentials.yaml.example
< spec/fixtures/accounts.json
< spec/spec_helper.rb
```

</details>