### PR TITLE
Fix NameErrorRequire: uninitialized constant ActiveSupport::IsolatedExecutionState

### DIFF
--- a/lib/avatax/api.rb
+++ b/lib/avatax/api.rb
@@ -1,5 +1,6 @@
 require File.expand_path('../connection', __FILE__)
 require File.expand_path('../request', __FILE__)
+require 'active_support'
 require 'active_support/notifications'
 require 'logger'
 


### PR DESCRIPTION
Rails does not support requiring a specific internal file without first requiring 'active_support'.

This change resolves the following error:

```
AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/activesupport-7.0.4.2/lib/active_support/notifications.rb:274:in `registry': uninitialized constant ActiveSupport::IsolatedExecutionState (NameError)
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/activesupport-7.0.4.2/lib/active_support/notifications.rb:269:in `instrumenter'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/activesupport-7.0.4.2/lib/active_support/notifications.rb:206:in `instrument'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/faraday-1.10.3/lib/faraday/request/instrumentation.rb:48:in `call'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/faraday-1.10.3/lib/faraday/rack_builder.rb:154:in `build_response'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/faraday-1.10.3/lib/faraday/connection.rb:516:in `run_request'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/faraday-1.10.3/lib/faraday/connection.rb:202:in `get'
	from AvaTax-REST-V2-Ruby-SDK/lib/avatax/request.rb:26:in `request'
	from AvaTax-REST-V2-Ruby-SDK/lib/avatax/request.rb:10:in `get'
	from AvaTax-REST-V2-Ruby-SDK/lib/avatax/client/companies.rb:428:in `query_companies'
	from AvaTax-REST-V2-Ruby-SDK/spec/spec_helper.rb:20:in `<top (required)>'
	from AvaTax-REST-V2-Ruby-SDK/spec/avatax/client/accounts_spec.rb:1:in `require'
	from AvaTax-REST-V2-Ruby-SDK/spec/avatax/client/accounts_spec.rb:1:in `<top (required)>'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1435:in `load'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1435:in `block in load_spec_files'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1433:in `each'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1433:in `load_spec_files'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:100:in `setup'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:86:in `run'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
	from AvaTax-REST-V2-Ruby-SDK/vendor/bundle/ruby/2.7.0/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
```