### PR TITLE
Use GitHub Actions for CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+---
+name: Tests
+on: [ push, pull_request ]
+jobs:
+  test:
+    name: Test (Ruby ${{ matrix.ruby }}, Rails ${{ matrix.rails }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: [ '2.5', '2.6', '2.7', '3.0', '3.1', '3.2' ]
+        rails: [ '6.1', '7.0' ]
+        exclude:
+          - { ruby: '2.5', rails: '7.0' }
+          - { ruby: '2.6', rails: '7.0' }
+    env:
+      BUNDLE_GEMFILE: gemfiles/rails-${{ matrix.rails }}.gemfile
+    steps:
+      - uses: actions/checkout@v3
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - run: bundle exec rake

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Submitting a Pull Request
 
 Build Status
 ------------
-[![Build Status](https://travis-ci.org/avadev/AvaTax-REST-V2-Ruby-SDK.svg?branch=master)](https://travis-ci.org/avadev/AvaTax-REST-V2-Ruby-SDK)
+[![Build Status](https://github.com/avadev/AvaTax-REST-V2-Ruby-SDK/actions/workflows/test.yml/badge.svg?branch=master)](https://github.com/avadev/AvaTax-REST-V2-Ruby-SDK/actions/workflows/test.yml)
 
 Copyright
 ---------

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -1,7 +1,7 @@
 require File.expand_path('../lib/avatax/version', __FILE__)
 
 Gem::Specification.new do |s|
-  s.add_development_dependency('rake', '~> 12.0.0')
+  s.add_development_dependency('rake', '~> 13.0')
   s.add_development_dependency('rspec', '~> 3.5.0')
   s.add_development_dependency('webmock', '>= 2.0.0')
   s.add_runtime_dependency('faraday', '>= 0.10')

--- a/avatax.gemspec
+++ b/avatax.gemspec
@@ -2,7 +2,7 @@ require File.expand_path('../lib/avatax/version', __FILE__)
 
 Gem::Specification.new do |s|
   s.add_development_dependency('rake', '~> 13.0')
-  s.add_development_dependency('rspec', '~> 3.5.0')
+  s.add_development_dependency('rspec', '~> 3.12')
   s.add_development_dependency('webmock', '>= 2.0.0')
   s.add_runtime_dependency('faraday', '>= 0.10')
   s.add_runtime_dependency('multi_json', '>= 1.0.3')

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gemspec path: '..'
+
+gem 'activesupport', '~> 6.1.0'

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+gemspec path: '..'
+
+gem 'activesupport', '~> 7.0.0'

--- a/spec/avatax/client/accounts_spec.rb
+++ b/spec/avatax/client/accounts_spec.rb
@@ -4,9 +4,11 @@ describe AvaTax::Client do
 
   describe ".accounts" do
     it "should return an array of accounts" do
+      pending('AvaTax sandbox credentials not set') if ENV['SANDBOX_USERNAME'].to_s.empty?
+
       accounts = @client.query_accounts
       expect(accounts).to be_a Object
-      expect(accounts['value'].first['id']).to be_a Integer
+      expect(accounts.dig('value', 0, 'id')).to be_a Integer
     end
   end
 

--- a/spec/avatax/client/transactions_spec.rb
+++ b/spec/avatax/client/transactions_spec.rb
@@ -30,6 +30,8 @@ describe AvaTax::Client do
     end
 
     it "should create a transaction" do
+      pending('AvaTax sandbox credentials not set') if ENV['SANDBOX_USERNAME'].to_s.empty?
+
       transaction = @client.create_transaction(@base_transaction)
       expect(transaction).to be_a Object
       expect(transaction["id"]).to be_a Integer

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,6 @@ companies = client.query_companies
 RSpec.configure do |config|
   config.before {
     @client = client
-    @company_code = companies["value"][0]["companyCode"]
+    @company_code = companies.dig('value', 0, 'companyCode')
   }
 end


### PR DESCRIPTION
### Proposed change

To give external development teams and the wider community confidence that this project is compatible with the latest versions of Ruby, I propose using GitHub Actions for public CI and to automatically run the test suite against a matrix of supported Ruby versions.
